### PR TITLE
Add version requirement for hstlib to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,15 @@ A large window size makes `mosdepth` do less work formatting numbers.
 Unless you want to install [nim](https://nim-lang.org), simply download the
 [binary from the releases](https://github.com/brentp/mosdepth/releases).
 
-If you get an error about "`libhts.so` not found", set `LD_LIBRARY_PATH`
-to the directory that contains `libhts.so`. e.g.
+`mosdepth` uses requires htslib version 1.4 or later. If you get an error 
+about "`libhts.so` not found", set `LD_LIBRARY_PATH` to the directory that 
+contains `libhts.so`. e.g.
 
-```LD_LIBRARY_PATH=~/src/htslib/ mosdepth -h```
+```LD_LIBRARY_PATH=~/src/htslib/ mosdepth -h
+```
+
+If you get the error `could not import: hts_check_EOF` you may need to 
+install a more recent version of htslib.
 
 If you do want to install from source, see the [travis.yml](https://github.com/brentp/mosdepth/blob/master/.travis.yml)
 and the [install.sh](https://github.com/brentp/mosdepth/blob/master/scripts/install.sh).


### PR DESCRIPTION
Thanks for what looks like a great tool (with a great name!). 

I noticed that the binaries require a more recent version of `hstlib` than are installed by default in some distros. This PR just makes
a note of the minimum version required and describes the error message that older versions will produce.