### PR TITLE
Exclude BED regions even with thresholds enabled

### DIFF
--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -545,7 +545,7 @@ proc main(bam: hts.Bam, chrom: region_t, mapq: int, eflag: uint16, iflag: uint16
     if region != nil:
       chrom_region_distribution = new_seq[int64](1000)
     # if we can skip per base and there's no regions from this chrom we can avoid coverage calc.
-    if skip_per_base and thresholds == nil and quantize == nil and bed_regions != nil and not bed_regions.contains(target.name):
+    if skip_per_base and thresholds == nil and quantize == nil and bed_regions != nil or not bed_regions.contains(target.name):
       continue
     rchrom = region_t(chrom: target.name)
     var tid = coverage(bam, arr, rchrom, mapq, eflag, iflag)


### PR DESCRIPTION
I align my reads against a genome with >232k scaffolds, but am only interested in coverage reports of a few of these scaffolds, and this causes mosdepth to eventually being killed because it runs out of memory. Attached is a suggested patch, which seems to work for my case at least.

--no-per-base with --by file.bed and -T seems to be causing this. 