### PR TITLE
small typo in wording 'noly' to 'only'

### DIFF
--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -845,7 +845,7 @@ Other options:
     region = $args["--by"]
   else:
     if thresholds.len != 0:
-      stderr.write_line("[mosdepth] error --thresholds can noly be used when --by is specified.")
+      stderr.write_line("[mosdepth] error --thresholds can only be used when --by is specified.")
       quit(2)
   GC_disableMarkAndSweep()
   var fasta: cstring = nil


### PR DESCRIPTION
Incredibly small typo fix.