### PR TITLE
Update docopt version to 0.7.1

### DIFF
--- a/mosdepth.nimble
+++ b/mosdepth.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "hts >= 0.3.22", "docopt == 0.7.0", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.3"
+requires "hts >= 0.3.22", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.3"
 
 bin = @["mosdepth"]
 skipDirs = @["tests"]


### PR DESCRIPTION
Hi @brentp,

I encountered an error while trying to compile mosdepth on an Apple M2 macOS. It appears that the issue can be resolved by updating docopt.

```
mosdepth on master is 📦 v0.3.8 via 👑 v2.0.8 
❯ nimble build -Y mosdepth.nimble
  Verifying dependencies for mosdepth@0.3.8
     Info:  Dependency on hts@>= 0.3.22 already satisfied
  Verifying dependencies for hts@0.3.25
     Info:  Dependency on docopt@0.7.0 already satisfied
  Verifying dependencies for docopt@0.7.0
     Info:  Dependency on regex@>= 0.11.1 already satisfied
  Verifying dependencies for regex@0.21.0
     Info:  Dependency on unicodedb@>= 0.7.2 already satisfied
  Verifying dependencies for unicodedb@0.12.0
     Info:  Dependency on https://github.com/brentp/d4-nim@>= 0.0.3 already satisfied
  Verifying dependencies for d4@0.0.3
   Building mosdepth/mosdepth using c backend
/Users/kojix2/.nimble/pkgs2/docopt-0.7.0-21150284640b882fa91147181c52da3e5bb44df8/docopt.nim(608, 6) Error: 'docopt' is not GC-safe as it calls 'docopt_exc'
       Tip: 12 messages have been suppressed, use --verbose to show them.
nimble.nim(304)          buildFromDir

    Error:  Build failed for the package: mosdepth
```

For more details, please see https://github.com/docopt/docopt.nim/issues/57 for more detail.

Thank you.