### PR TITLE
Fix compilation error by removing 'shallow' for Nim 2.0 compatibility

### DIFF
--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -504,7 +504,6 @@ proc write_thresholds(fh:BGZI, tid:int, arr:var coverage_t, thresholds:seq[int],
     return
 
   var counts = new_seq[int](len(thresholds))
-  shallow(arr)
 
   # iterate over the region and count bases >= request cutoffs.
   for v in arr[start..<stop]:
@@ -630,7 +629,6 @@ proc main(bam: hts.Bam, chrom: region_t, mapq: int, min_len: int, max_len: int, 
       window = uint32(S.parse_int(region))
     else:
       bed_regions = bed_to_table(region)
-  shallow(arr)
 
   var cs = initCountStat[uint32](size=if use_median: 65536 else: 0)
 

--- a/mosdepth.nimble
+++ b/mosdepth.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "hts >= 0.3.22", "docopt == 0.7.0", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.3"
+requires "hts >= 0.3.22", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.3"
 
 bin = @["mosdepth"]
 skipDirs = @["tests"]


### PR DESCRIPTION
Hi @brentp,

This is a follow-up to PR #235.

When attempting to compile mosdepth, I encountered an error related to shallow.

```
mosdepth on docopt is 📦 v0.3.8 via 👑 v2.0.8 
❯ nimble build -Y mosdepth.nimble
  Verifying dependencies for mosdepth@0.3.8
     Info:  Dependency on hts@>= 0.3.22 already satisfied
  Verifying dependencies for hts@0.3.25
     Info:  Dependency on docopt@0.7.1 already satisfied
  Verifying dependencies for docopt@0.7.1
     Info:  Dependency on regex@>= 0.11.1 already satisfied
  Verifying dependencies for regex@0.21.0
     Info:  Dependency on unicodedb@>= 0.7.2 already satisfied
  Verifying dependencies for unicodedb@0.12.0
     Info:  Dependency on https://github.com/brentp/d4-nim@>= 0.0.3 already satisfied
  Verifying dependencies for d4@0.0.3
   Building mosdepth/mosdepth using c backend
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(63, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(66, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(74, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(507, 3) Error: undeclared identifier: 'shallow'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (3, 4): 'alloc'
 (3, 4): 'dealloc'
 (3, 4): 'realloc'
       Tip: 12 messages have been suppressed, use --verbose to show them.
nimble.nim(304)          buildFromDir

    Error:  Build failed for the package: mosdepth
```

It appears to be the same issue as reported in https://github.com/brentp/mosdepth/issues/209.

Removing shallow resolved the compilation issue, and the tests passed successfully.

```
mosdepth on  docopt [!?] is 📦 v0.3.8 via 👑 v2.0.8 
❯ nim c -r tests/all.nim 
Hint: used config file '/opt/homebrew/Cellar/nim/2.0.8/nim/config/nim.cfg' [Conf]
Hint: used config file '/opt/homebrew/Cellar/nim/2.0.8/nim/config/config.nims' [Conf]
Hint: used config file '/Users/kojix2/Nim/mosdepth/nim.cfg' [Conf]
Hint: used config file '/Users/kojix2/Nim/mosdepth/tests/nim.cfg' [Conf]
...............................................................................................................................................................................
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(63, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(66, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(265, 18) template/generic instantiation of `tag` from here
/Users/kojix2/.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam/auxtags.nim(74, 7) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(608, 15) Warning: open; wopen_bgzi is deprecated [Deprecated]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(611, 17) Warning: open; wopen_bgzi is deprecated [Deprecated]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(614, 19) Warning: open; wopen_bgzi is deprecated [Deprecated]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(627, 15) Warning: open; wopen_bgzi is deprecated [Deprecated]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(544, 6) Hint: 'to_tuples' is declared but not used [XDeclaredButNotUsed]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(549, 6) Hint: 'main' is declared but not used [XDeclaredButNotUsed]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(767, 6) Hint: 'check_chrom' is declared but not used [XDeclaredButNotUsed]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(782, 6) Hint: 'check_cram_has_ref' is declared but not used [XDeclaredButNotUsed]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(9, 8) Warning: imported and not used: 'strformat' [UnusedImport]
/Users/kojix2/Nim/mosdepth/mosdepth.nim(11, 8) Warning: imported and not used: 'times' [UnusedImport]
/Users/kojix2/Nim/mosdepth/tests/funcs.nim(4, 8) Warning: imported and not used: 'os' [UnusedImport]
/Users/kojix2/Nim/mosdepth/tests/all.nim(1, 8) Warning: imported and not used: 'funcs' [UnusedImport]
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/exceptions.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/since.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/ctypes.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/sysatomics.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/ansi_c.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/memory.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/syslocks.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/threadtypes.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/digitsutils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/miscdollars.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/assertions.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/iterators.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/coro_detection.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/dragonbox.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/schubfach.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/formatfloat.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/objectdollar.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/dollars.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/typedthreads.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/stacktraces.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/bitops_utils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/countbits_impl.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system/repr_v2.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/widestrs.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/syncio.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/system.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/core/locks.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/exitprocs.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/core/macros.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/parseutils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/bitops.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/fenv.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/math.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/algorithm.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/typetraits.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/enumutils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/strbasics.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/unicode.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/jsutils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/strimpl.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/strutils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/streams.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/options.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/posix/posix.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/times.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/hashes.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/outparams.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/collections/sets.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/collections/sequtils.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/osseps.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/pathnorm.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/oserrors.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/oscommon.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/ospaths2.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/ossymlinks.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/osfiles.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/osdirs.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/envvars.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/private/osappdirs.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/std/cmdline.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/os.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/strformat.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/colors.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/posix/termios.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/terminal.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/unittest.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/private/hts_concat.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/utils.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/simpleoption.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bam.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/vcf.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/fai.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bgzf.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/csi.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/bgzf/bgzi.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts/stats.nim
CC: ../../../.nimble/pkgs2/hts-0.3.25-c05c9adf6b2e10a7f07edfef29110ea14bb66611/hts.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/collections/tables.nim
CC: ../int2str.nim
CC: ../../../.nimble/pkgs2/unicodedb-0.12.0-4452416471e2fe8726eb6070ed6ea7368171cc09/unicodedb/properties_data.nim
CC: ../../../.nimble/pkgs2/unicodedb-0.12.0-4452416471e2fe8726eb6070ed6ea7368171cc09/unicodedb/properties.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/common.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/types.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/exptype.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/scanner.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/parser.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/exptransformation.nim
CC: ../../../.nimble/pkgs2/unicodedb-0.12.0-4452416471e2fe8726eb6070ed6ea7368171cc09/unicodedb/types_data.nim
CC: ../../../.nimble/pkgs2/unicodedb-0.12.0-4452416471e2fe8726eb6070ed6ea7368171cc09/unicodedb/types.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nodematch.nim
CC: ../../../../../opt/homebrew/Cellar/nim/2.0.8/nim/lib/pure/collections/deques.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfa.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/litopt.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfatype.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/compiler.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfamatch.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfafindall.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfamatch2.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfafindall2.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex/nfamacro.nim
CC: ../../../.nimble/pkgs2/regex-0.21.0-3e6b482026bcd9113b0e05026d641248e6c51709/regex.nim
CC: ../../../.nimble/pkgs2/docopt-0.7.1-387f1ae17f3b7620c7814cf44a52d3d91b8906e9/docopt/util.nim
CC: ../../../.nimble/pkgs2/docopt-0.7.1-387f1ae17f3b7620c7814cf44a52d3d91b8906e9/docopt.nim
CC: ../depthstat.nim
CC: ../mosdepth.nim
CC: funcs.nim
CC: all.nim
Hint:  [Link]
ld: warning: ignoring duplicate libraries: '-lm'
Hint: mm: orc; threads: on; opt: none (DEBUG BUILD, `-d:release` generates faster code)
81827 lines; 1.253s; 167.652MiB peakmem; proj: /Users/kojix2/Nim/mosdepth/tests/all.nim; out: /Users/kojix2/Nim/mosdepth/tests/all [SuccessX]
Hint: /Users/kojix2/Nim/mosdepth/tests/all [Exec]

[Suite] mosdepth-suite
  [OK] depthstat min
  [OK] test-quantize-args
  [OK] linear-search
  [OK] lookup
  [OK] threshold-args
  [OK] name splitting
```

mosdepth is a project that focuses on speed, so I understand if you don't want to remove optimization code. Please note that this is just a suggestion from someone not very familiar with Nim. 
Thank you for your great project and hard work.