### PR TITLE
Errors in BAM iterator should be fatal

### DIFF
--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -184,6 +184,9 @@ iterator regions(bam: hts.Bam, region: region_t, tid: int, targets: seq[
       try:
         for r in bam.query(tid, int(region.start), int(stop)):
           yield r
+      # if the iterator fails due to an invalid read from the BAM (due to file
+      # corruption or filesystem issues), we want to gracefully exit with a
+      # nonzero return.
       except hts.BamError:
         quit getCurrentExceptionMsg()
     else:

--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -184,7 +184,7 @@ iterator regions(bam: hts.Bam, region: region_t, tid: int, targets: seq[
       try:
         for r in bam.query(tid, int(region.start), int(stop)):
           yield r
-      except IOError:
+      except hts.BamError:
         quit getCurrentExceptionMsg()
     else:
       stderr.write_line("[mosdepth]", region.chrom, " not found")

--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -181,8 +181,11 @@ iterator regions(bam: hts.Bam, region: region_t, tid: int, targets: seq[
     if tid != -1:
       if stop == 0:
         stop = targets[tid].length
-      for r in bam.query(tid, int(region.start), int(stop)):
-        yield r
+      try:
+        for r in bam.query(tid, int(region.start), int(stop)):
+          yield r
+      except IOError:
+        quit getCurrentExceptionMsg()
     else:
       stderr.write_line("[mosdepth]", region.chrom, " not found")
 

--- a/mosdepth.nimble
+++ b/mosdepth.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "https://github.com/julianhess/hts-nim >= 0.3.31", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
+requires "hts >= 0.3.31", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
 
 bin = @["mosdepth"]
 skipDirs = @["tests"]

--- a/mosdepth.nimble
+++ b/mosdepth.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "https://github.com/julianhess/hts-nim >= 0.3.30", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
+requires "https://github.com/julianhess/hts-nim >= 0.3.31", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
 
 bin = @["mosdepth"]
 skipDirs = @["tests"]

--- a/mosdepth.nimble
+++ b/mosdepth.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "hts >= 0.3.29", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
+requires "https://github.com/julianhess/hts-nim >= 0.3.30", "docopt == 0.7.1", "nim >= 1.0.0", "https://github.com/brentp/d4-nim >= 0.0.5"
 
 bin = @["mosdepth"]
 skipDirs = @["tests"]


### PR DESCRIPTION
If this iteration fails, it's likely due to a corrupted BAM (or in my case, an unstable cloud filesystem mount). The current approach of simply logging a message to stderr is suboptimal, since this results in a truncated coverage file and a successful exit code, which is difficult to catch in pipelines. To address this, I've modified `Bam.query()` in `hts-nim` (submitted as a separate pull request [here](https://github.com/brentp/hts-nim/pull/91)) to raise an exception, which is then caught and handled (with a nonzero exit) in mosdepth.