### PR TITLE
Fix `argment` -> `argument` typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ more details.
 
 ## thresholds
 
-given a set of regions to the `--by` argment, `mosdepth` can report the number of bases in each region that
+given a set of regions to the `--by` argument, `mosdepth` can report the number of bases in each region that
 are covered at or above each threshold value given to `--thresholds`. e.g:
 ```
 


### PR DESCRIPTION
Line 228 of README.md has `argment` (missing letter) in the description of the `--by` flag.