### PR TITLE
Add --progress/-p flag for per-chromosome stderr progress events

### DIFF
--- a/mosdepth.nim
+++ b/mosdepth.nim
@@ -589,7 +589,7 @@ proc to_tuples(targets: seq[Target]): seq[tuple[name: string, length: int]] =
 proc main(bam: hts.Bam, chrom: region_t, mapq: int, min_len: int, max_len: int, eflag: uint16, iflag: uint16, region: string, thresholds: seq[int],
           fast_mode: bool, args: Table[string, docopt.Value],
               use_median: bool = false, fragment_mode: bool = false,
-              use_d4: bool = false) =
+              use_d4: bool = false, progress: bool = false) =
   # windows are either from regions, or fixed-length windows.
   # we assume the input is sorted by chrom.
   var
@@ -694,6 +694,8 @@ proc main(bam: hts.Bam, chrom: region_t, mapq: int, min_len: int, max_len: int, 
           ". percent of contigs completed:", su.format_float(100 *
           ii/sub_targets.len, ffDecimal, precision = 2))
     ii += 1
+    if progress:
+      stderr.write_line("[progress] chrom ", target.name, " ", ii, " of ", sub_targets.len)
     zeroMem(chrom_global_distribution[0].addr, len(chrom_global_distribution) *
         sizeof(chrom_global_distribution[0]))
     if region != "":
@@ -913,6 +915,7 @@ Other options:
                                     by ','.
   -m --use-median                   output median of each region (in --by) instead of mean.
   -R --read-groups <string>         only calculate depth for these comma-separated read groups IDs.
+  -p --progress                     emit a [progress] line to stderr at the start of each chromosome.
   -h --help                         show help
   """
 
@@ -942,6 +945,7 @@ Other options:
     var use_d4: bool = args["--d4"] and not args["--no-per-base"]
   else:
     var use_d4: bool = false
+  var progress: bool = args["--progress"]
 
   if fragment_mode and fast_mode:
     stderr.write_line("[mosdepth] error only one of --fast-mode and --fragment-mode can be specified")
@@ -986,4 +990,4 @@ Other options:
 
   main(bam, chrom, mapq, min_len, max_len, eflag, iflag, region, thresholds,
       fast_mode, args, use_median = use_median, fragment_mode = fragment_mode,
-      use_d4 = use_d4)
+      use_d4 = use_d4, progress = progress)


### PR DESCRIPTION
Closes #269.

## What this changes

Adds a new boolean flag `-p` / `--progress`. When set, mosdepth writes one line to stderr **before** starting work on each contig:

```
[progress] chrom chr1 1 of 24
[progress] chrom chr2 2 of 24
...
[progress] chrom chrY 24 of 24
```

## Why

During a `--fast-mode --no-per-base` WGS coverage pass (the hot path for many pipelines), stderr is silent for 5–10 minutes. Pipeline wrappers that want to surface a live progress bar have nothing to tail. This flag gives them one machine-parseable event per contig — enough resolution for a smooth bar with minimal log noise.

Design decisions:
- **`[progress]` prefix** so a regex cleanly distinguishes these lines from htslib `[W::*]` / `[M::*]` warnings.
- **`\n`-terminated** (no `\r`) — line-by-line tailers work correctly.
- **`N of M` on every line** — a parser can compute `fraction = N/M` without external state.
- **Emitted before the contig's work** — end-of-chrom events are useless because the last contig wouldn't update until the work is done.
- **Opt-in** — no change to default behavior, not gated behind `-v`/`--verbose`.

## Implementation

6 lines across 4 hunks in `mosdepth.nim`:

1. `progress: bool = false` parameter added to `main`.
2. In the per-contig loop, after `ii += 1`, an `if progress:` branch writes the line to stderr — placed before any `continue` statements so every contig in `sub_targets` gets an event.
3. `-p --progress` added to the docopt string (same style as `-x --fast-mode`, `-a --fragment-mode`).
4. `var progress: bool = args["--progress"]` extracted and passed to `main`, matching the existing pattern for `fast_mode` / `use_median`.

## Testing

Built with Nim 2.2.10, `nim c --mm:refc -d:release mosdepth.nim` — no new errors or warnings (all warnings are pre-existing in the upstream tree).

Smoke-tested against BAMs in the `tests/` directory:

```
$ ./mosdepth --progress --fast-mode --no-per-base /tmp/out tests/nanopore.bam 2>&1 | head -5
[progress] chrom LXWQ01000001.1 1 of 408
[progress] chrom KV452454.1 2 of 408
[progress] chrom KV452455.1 3 of 408
[progress] chrom LXWQ01000031.1 4 of 408
[progress] chrom KV452456.1 5 of 408

$ ./mosdepth --progress --fast-mode --no-per-base /tmp/out tests/big.bam 2>&1
[progress] chrom ref 1 of 1

$ ./mosdepth /tmp/out tests/big.bam 2>&1
(no output — default behavior unchanged)
```